### PR TITLE
Rule for deploying NPM packages

### DIFF
--- a/npm/rules.bzl
+++ b/npm/rules.bzl
@@ -1,0 +1,75 @@
+#
+# GRAKN.AI - THE KNOWLEDGE GRAPH
+# Copyright (C) 2018 Grakn Labs Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+def _deploy_npm_impl(ctx):
+    preprocessed_deploy_script = ctx.actions.declare_file('_deploy.sh')
+
+    ctx.actions.expand_template(
+        output = preprocessed_deploy_script,
+        template = ctx.file._deployment_script_template,
+        substitutions = {
+            "$BAZEL_PACKAGE_NAME": ctx.attr.target.label.package,
+            "$BAZEL_TARGET_NAME": ctx.attr.target.label.name,
+        }
+    )
+
+    ctx.actions.run_shell(
+        inputs = [preprocessed_deploy_script, ctx.file.version_file],
+        outputs = [ctx.outputs.deployment_script],
+        command = "VERSION=`cat %s` && sed -e s/{version}/$VERSION/g %s > %s" % (
+                    ctx.file.version_file.path, preprocessed_deploy_script.path, ctx.outputs.deployment_script.path)
+    )
+
+    return DefaultInfo(executable = ctx.outputs.deployment_script,
+                       runfiles = ctx.runfiles(
+                           files = ctx.files.target + ctx.files._node_runfiles + [ctx.file.deployment_properties],
+                           symlinks = {
+                               "deployment.properties": ctx.file.deployment_properties
+                           }))
+
+deploy_npm = rule(
+    implementation = _deploy_npm_impl,
+    attrs = {
+        "target": attr.label(
+            mandatory = True,
+            doc = "`npm_library` label to be included in the package",
+        ),
+        "version_file": attr.label(
+            allow_single_file = True,
+            mandatory = True,
+            doc = "File containing version string"
+        ),
+        "deployment_properties": attr.label(
+            allow_single_file = True,
+            mandatory = True,
+            doc = "File containing Node repository url by `npm.repository-url` key"
+        ),
+        "_deployment_script_template": attr.label(
+            allow_single_file = True,
+            default = "//npm/templates:deploy.sh",
+        ),
+        "_node_runfiles": attr.label(
+            default = Label("@nodejs//:node_runfiles"),
+            allow_files = True
+        )
+    },
+    executable = True,
+    outputs = {
+          "deployment_script": "%{name}.sh",
+    }
+)

--- a/npm/templates/BUILD
+++ b/npm/templates/BUILD
@@ -1,0 +1,19 @@
+#
+# GRAKN.AI - THE KNOWLEDGE GRAPH
+# Copyright (C) 2018 Grakn Labs Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+exports_files(["deploy.sh"])

--- a/npm/templates/deploy.sh
+++ b/npm/templates/deploy.sh
@@ -1,0 +1,56 @@
+#
+# GRAKN.AI - THE KNOWLEDGE GRAPH
+# Copyright (C) 2018 Grakn Labs Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+#!/usr/bin/env bash
+
+set -ex
+
+if [[ $# -ne 3 ]]; then
+    echo "Should pass <npm-username> <npm-password> <npm-email> as arguments"
+    exit 1
+fi
+
+NPM_USERNAME="$1"
+NPM_PASSWORD="$2"
+NPM_EMAIL="$3"
+
+# create a temporary file for preprocessing deployment.properties
+DEPLOYMENT_PROPERTIES_STRIPPED_FILE=$(mktemp)
+# awk in the next line strips out empty and comment lines
+awk '!/^#/ && /./' deployment.properties > ${DEPLOYMENT_PROPERTIES_STRIPPED_FILE}
+NPM_REPOSITORY_URL=$(grep "npm.repository-url" ${DEPLOYMENT_PROPERTIES_STRIPPED_FILE} | cut -d '=' -f 2)
+
+export PATH="$(dirname $(readlink external/nodejs/bin/nodejs/bin/npm)):$PATH"
+export VERSION="{version}"
+cd "$BAZEL_PACKAGE_NAME/$BAZEL_TARGET_NAME"
+
+chmod a+w .
+sed -i '' "s/0.0.0-development/$VERSION/g" package.json
+
+# Log in to `npm`
+/usr/bin/expect <<EOD
+spawn npm adduser --registry=$NPM_REPOSITORY_URL
+expect {
+  "Username:" {send "$NPM_USERNAME\r"; exp_continue}
+  "Password:" {send "$NPM_PASSWORD\r"; exp_continue}
+  "Email: (this IS public)" {send "$NPM_EMAIL\r"; exp_continue}
+}
+EOD
+
+# Use *without* packing instead because
+npm publish


### PR DESCRIPTION
Rule adds `deploy_npm` Bazel rule.

# Purpose
Facilitate deployment of `npm_package` targets to NPM

# Sample usage
```
deploy_npm(
    name = "deploy-npm",
    target = ":target-to-deploy,
    version_file = "//:VERSION",
    deployment_properties = "//:deployment.properties",
)
```

`bazel run //:deploy-npm -- <npm-username> <npm-password> <npm-email>`

`package.json` should contain a placeholder version of `0.0.0-development` which will be replaced with a string from `version_file`

`deployment_properties` should contain `npm.repository_url=REPO_URL` where `REPO_URL` is a valid NPM repo URL

Handles these tasks:
* logs in to NPM with credentials read from command line arguments
* updates version statement in `package.json`
* runs `npm publish` to push an updated archive to NPM