### PR TITLE
Implement rules for building zip distribution

### DIFF
--- a/distribution/BUILD
+++ b/distribution/BUILD
@@ -1,0 +1,19 @@
+#
+# GRAKN.AI - THE KNOWLEDGE GRAPH
+# Copyright (C) 2018 Grakn Labs Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+exports_files(["archiver.py"])

--- a/distribution/archiver.py
+++ b/distribution/archiver.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+
+#
+# GRAKN.AI - THE KNOWLEDGE GRAPH
+# Copyright (C) 2018 Grakn Labs Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+from __future__ import print_function
+import zipfile
+
+moves = eval('{moves}')
+empty_directories = eval('{empty_directories}')
+
+with zipfile.ZipFile('{distribution_zip_location}', 'w', zipfile.ZIP_DEFLATED) as zf:
+    for fn, arcfn in moves.items():
+        zf.write(fn, arcfn)
+    for emptydir in empty_directories:
+        zf.writestr(emptydir + '/', '')

--- a/distribution/archiver.py
+++ b/distribution/archiver.py
@@ -28,4 +28,7 @@ with zipfile.ZipFile('{distribution_zip_location}', 'w', zipfile.ZIP_DEFLATED) a
     for fn, arcfn in moves.items():
         zf.write(fn, arcfn)
     for emptydir in empty_directories:
-        zf.writestr(emptydir + '/', '')
+        zi = zipfile.ZipInfo(emptydir + '/')
+        zi.compress_type = zipfile.ZIP_DEFLATED
+        zi.external_attr = 0o40775 << 16
+        zf.writestr(zi, '')

--- a/distribution/rules.bzl
+++ b/distribution/rules.bzl
@@ -53,6 +53,8 @@ def _distribution_impl(ctx):
         executable = archiver_script
     )
 
+    return DefaultInfo(data_runfiles = ctx.runfiles(files=[ctx.outputs.distribution]))
+
 
 distribution = rule(
     attrs = {
@@ -77,5 +79,6 @@ distribution = rule(
     outputs = {
         "distribution": "%{name}.zip"
     },
+    output_to_genfiles = True,
     doc = "Create a distribution of Java program(s) containing additional files"
 )

--- a/distribution/rules.bzl
+++ b/distribution/rules.bzl
@@ -1,0 +1,81 @@
+#
+# GRAKN.AI - THE KNOWLEDGE GRAPH
+# Copyright (C) 2018 Grakn Labs Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+def _distribution_impl(ctx):
+    # files to put into archive
+    files = []
+    # maps real fs paths to paths inside archive
+    names = {}
+
+    for target in ctx.attr.targets:
+        for file in target.data_runfiles.files:
+            if file.extension == 'jar':
+                names[file.path] = ctx.attr.java_deps_root + file.basename
+                files.append(file)
+
+    for label, filename in ctx.attr.additional_files.items():
+        if len(label.files) != 1:
+            fail("should specify target producing single file instead of {}".format(label))
+        single_file = label.files.to_list()[0]
+        names[single_file.path] = filename
+
+    archiver_script = ctx.actions.declare_file('_archiver.py')
+
+    ctx.actions.expand_template(
+        template = ctx.file._distribution_py,
+        output = archiver_script,
+        substitutions = {
+            "{moves}": str(names),
+            "{distribution_zip_location}": ctx.outputs.distribution.path,
+            "{empty_directories}": str(ctx.attr.empty_directories)
+        },
+        is_executable = True
+    )
+
+    ctx.actions.run(
+        outputs = [ctx.outputs.distribution],
+        inputs = files + ctx.files.additional_files,
+        executable = archiver_script
+    )
+
+
+distribution = rule(
+    attrs = {
+        "targets": attr.label_list(mandatory=True),
+        "java_deps_root": attr.string(
+            default = "services/lib/",
+            doc = "Folder inside archive to put JARs into"
+        ),
+        "additional_files": attr.label_keyed_string_dict(
+            allow_files = True,
+            doc = "Additional files to put into archive"
+        ),
+        "empty_directories": attr.string_list(
+            doc = "List of names to create empty directories inside archive"
+        ),
+        "_distribution_py": attr.label(
+            allow_single_file = True,
+            default="//distribution:archiver.py"
+        )
+    },
+    implementation = _distribution_impl,
+    outputs = {
+        "distribution": "%{name}.zip"
+    },
+    doc = "Create a distribution of Java program(s) containing additional files"
+)

--- a/distribution/rules.bzl
+++ b/distribution/rules.bzl
@@ -63,10 +63,10 @@ distribution = rule(
         ),
         "additional_files": attr.label_keyed_string_dict(
             allow_files = True,
-            doc = "Additional files to put into archive"
+            doc = "Additional files to put into the archive"
         ),
         "empty_directories": attr.string_list(
-            doc = "List of names to create empty directories inside archive"
+            doc = "List of names to create empty directories inside the archive"
         ),
         "_distribution_py": attr.label(
             allow_single_file = True,

--- a/distribution/rules.bzl
+++ b/distribution/rules.bzl
@@ -70,6 +70,10 @@ distribution = rule(
         "empty_directories": attr.string_list(
             doc = "List of names to create empty directories inside the archive"
         ),
+        "output_filename": attr.string(
+            doc = "Filename for result of rule execution",
+            mandatory = True
+        ),
         "_distribution_py": attr.label(
             allow_single_file = True,
             default="//distribution:archiver.py"
@@ -77,7 +81,7 @@ distribution = rule(
     },
     implementation = _distribution_impl,
     outputs = {
-        "distribution": "%{name}.zip"
+        "distribution": "%{output_filename}.zip"
     },
     output_to_genfiles = True,
     doc = "Create a distribution of Java program(s) containing additional files"


### PR DESCRIPTION
Adds a rule which allows you to pack `java_binary` targets together with their dependencies, additional files and empty directories. Produces a `.zip` as a result
Sample usage:
```
distribution(
    name = "distribution",
    targets = ["//server:server-binary"],
    additional_files = {
         "//:grakn": 'grakn',
         "//server:conf/logback.xml": "conf/logback.xml",
         "//server:conf/grakn.properties": "conf/grakn.properties",
         "//server:services/cassandra/cassandra.yaml": "services/cassandra/cassandra.yaml",
         "//server:services/cassandra/logback.xml": "services/cassandra/logback.xml",
         "//server:services/grakn/grakn-core-ascii.txt": "services/grakn/grakn-core-ascii.txt"
    },
    empty_directories = [
        "db/cassandra",
        "db/queue"
    ],
    visibility = ["//visibility:public"]
)
```