### PR TITLE
Fix removed native bazel rules (http_file)

### DIFF
--- a/github/dependencies.bzl
+++ b/github/dependencies.bzl
@@ -16,13 +16,14 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 
 def dependencies_for_github_deployment():
-    native.http_file(
+    http_file(
         name = "ghr_osx_zip",
         urls = ["https://github.com/tcnksm/ghr/releases/download/v0.10.2/ghr_v0.10.2_darwin_386.zip"]
     )
-    native.http_file(
+    http_file(
         name = "ghr_linux_tar",
         urls = ["https://github.com/tcnksm/ghr/releases/download/v0.10.2/ghr_v0.10.2_linux_386.tar.gz"]
     )


### PR DESCRIPTION
Native [`http_file`](https://docs.bazel.build/versions/master/be/workspace.html#http_file) is now deprecated