### PR TITLE
Fix 'depset_is_not_iterable' incompatible change

### DIFF
--- a/distribution/rules.bzl
+++ b/distribution/rules.bzl
@@ -23,13 +23,13 @@ def _distribution_impl(ctx):
     names = {}
 
     for target in ctx.attr.targets:
-        for file in target.data_runfiles.files:
+        for file in target.data_runfiles.files.to_list():
             if file.extension == 'jar':
                 names[file.path] = ctx.attr.java_deps_root + file.basename
                 files.append(file)
 
     for label, filename in ctx.attr.additional_files.items():
-        if len(label.files) != 1:
+        if len(label.files.to_list()) != 1:
             fail("should specify target producing single file instead of {}".format(label))
         single_file = label.files.to_list()[0]
         names[single_file.path] = filename

--- a/maven/templates/rules.bzl
+++ b/maven/templates/rules.bzl
@@ -182,7 +182,7 @@ def _transitive_maven_dependencies(_target, ctx):
     tags = []
 
     if MavenInfo in _target:
-        for x in _target[MavenInfo].maven_dependencies:
+        for x in _target[MavenInfo].maven_dependencies.to_list():
             tags.append(x)
 
     for dep in getattr(ctx.rule.attr, "jars", []):


### PR DESCRIPTION
Fixes future-incompatible change: `depset` will be [no longer iterable](https://docs.bazel.build/versions/master/skylark/backward-compatibility.html#depset-is-no-longer-iterable) in future version of `bazel`