### PR TITLE
Rules for Debian distribution

### DIFF
--- a/distribution/java_deps.py
+++ b/distribution/java_deps.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 #
 # GRAKN.AI - THE KNOWLEDGE GRAPH
 # Copyright (C) 2018 Grakn Labs Ltd
@@ -16,4 +18,11 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-exports_files(["archiver.py", "java_deps.py"])
+from __future__ import print_function
+import tarfile
+
+moves = eval('{moves}')
+
+with tarfile.open('{distribution_tgz_location}', 'w:gz', dereference=True) as tgz:
+    for fn, arcfn in moves.items():
+        tgz.add(fn, arcfn)

--- a/distribution/rules.bzl
+++ b/distribution/rules.bzl
@@ -99,7 +99,8 @@ def deploy_deb(name,
                empty_dirs = [],
                files = {},
                depends = [],
-               symlinks = {}):
+               symlinks = {},
+               modes = {}):
     java_deps_tar = []
     if target:
         java_deps(
@@ -116,7 +117,8 @@ def deploy_deb(name,
         package_dir = package_dir,
         empty_dirs = empty_dirs,
         files = files,
-        symlinks = symlinks
+        symlinks = symlinks,
+        modes = modes,
     )
 
     pkg_deb(

--- a/distribution/rules.bzl
+++ b/distribution/rules.bzl
@@ -122,7 +122,7 @@ def deploy_deb(name,
     )
 
     pkg_deb(
-        name = "{}-deb".format(name),
+        name = "deploy-deb",
         data = "_{}-tar".format(name),
         package = name,
         depends = depends,

--- a/distribution/rules.bzl
+++ b/distribution/rules.bzl
@@ -98,7 +98,8 @@ def deploy_deb(name,
                target = None,
                empty_dirs = [],
                files = {},
-               depends = []):
+               depends = [],
+               symlinks = {}):
     java_deps_tar = []
     if target:
         java_deps(
@@ -115,6 +116,7 @@ def deploy_deb(name,
         package_dir = package_dir,
         empty_dirs = empty_dirs,
         files = files,
+        symlinks = symlinks
     )
 
     pkg_deb(


### PR DESCRIPTION
This PR adds the following:
* `java_deps` rule which takes in `java_binary` and puts it together will all dependencies into a `.tgz` archive at directory `java_deps_root`. This is only meant for internal consumption of `pkg_deb`
* `deploy_deb` macro which builds final `.deb`:
```
deploy_deb(
    name = "X"
)
```

Resulting Debian package will be called `X`, target to build it is `//:X-deb`