### PR TITLE
Reimplement deployment rule as a macro

### DIFF
--- a/distribution/BUILD
+++ b/distribution/BUILD
@@ -16,4 +16,4 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-exports_files(["archiver.py", "java_deps.py"])
+exports_files(["archiver.py", "java_deps.py", "tgz2zip.py"])

--- a/distribution/tgz2zip.py
+++ b/distribution/tgz2zip.py
@@ -19,12 +19,23 @@
 #
 
 from __future__ import print_function
+import sys
+import zipfile
 import tarfile
 
-import sys
-_, moves, distribution_tgz_location = sys.argv
-moves = eval(moves)
+_, tgz_fn, zip_fn = sys.argv
 
-with tarfile.open(distribution_tgz_location, 'w:gz', dereference=True) as tgz:
-    for fn, arcfn in moves.items():
-        tgz.add(fn, arcfn)
+with tarfile.open(tgz_fn, mode='r') as tgz:
+    with zipfile.ZipFile(zip_fn, 'w', compression=zipfile.ZIP_DEFLATED) as zip:
+        for tarinfo in tgz.getmembers():
+            f = ''
+            name = tarinfo.name
+            if not tarinfo.isdir():
+                f = tgz.extractfile(tarinfo).read()
+            else:
+                name += '/'
+            zi = zipfile.ZipInfo(name)
+            zi.compress_type = zipfile.ZIP_DEFLATED
+            zi.external_attr = tarinfo.mode << 16
+            zip.writestr(zi, f)
+


### PR DESCRIPTION
* Renames `distribution` (rule) and `_distribution_impl` (rule implementation) to `old_distribution` and old_distribution_impl`. Those are subject to removal.
* Adds `tgz2zip` rule, which converts `tar` archives to `zip`
* `java_deps` now only takes single target
* Reimplement `distribution` as a macro, which expands into sequence `java_deps` -> `pkg_tar` -> `tgz2zip`