### PR TITLE
Put distribution into its own folder _inside_ the archive

### DIFF
--- a/distribution/rules.bzl
+++ b/distribution/rules.bzl
@@ -44,7 +44,7 @@ def _tgz2zip_impl(ctx):
         inputs = [ctx.file.tgz],
         outputs = [ctx.outputs.zip],
         executable = ctx.file._tgz2zip_py,
-        arguments = [ctx.file.tgz.path, ctx.outputs.zip.path],
+        arguments = [ctx.file.tgz.path, ctx.outputs.zip.path, ctx.attr.prefix],
         progress_message = "Converting {} to {}".format(ctx.file.tgz.short_path, ctx.outputs.zip.short_path)
     )
 
@@ -179,6 +179,7 @@ def distribution(targets,
         name = "distribution",
         tgz = ":distribution_tgz",
         output_filename = output_filename,
+        prefix = "./" + output_filename,
         visibility = ["//visibility:public"]
     )
 
@@ -209,6 +210,9 @@ tgz2zip = rule(
         ),
         "output_filename": attr.string(
             mandatory = True,
+        ),
+        "prefix": attr.string(
+            default="."
         ),
         "_tgz2zip_py": attr.label(
             allow_single_file = True,

--- a/distribution/tgz2zip.py
+++ b/distribution/tgz2zip.py
@@ -19,17 +19,18 @@
 #
 
 from __future__ import print_function
+import os
 import sys
 import zipfile
 import tarfile
 
-_, tgz_fn, zip_fn = sys.argv
+_, tgz_fn, zip_fn, prefix = sys.argv
 
 with tarfile.open(tgz_fn, mode='r') as tgz:
     with zipfile.ZipFile(zip_fn, 'w', compression=zipfile.ZIP_DEFLATED) as zip:
         for tarinfo in tgz.getmembers():
             f = ''
-            name = tarinfo.name
+            name = './' + os.path.normpath(os.path.join(prefix, tarinfo.name))
             if not tarinfo.isdir():
                 f = tgz.extractfile(tarinfo).read()
             else:


### PR DESCRIPTION
Modifies `distribution` in such a way that it produces an archive, in which contents are prepended by extra directory, i.e. for `//:distribution` of [graknlabs/grakn](https://github.com/graknlabs/grakn/), when unpacking, it would produce folder structure resembling this:
```
./grakn-core-all/
./grakn-core-all/conf/
./grakn-core-all/console/…
./grakn-core-all/grakn
./grakn-core-all/logs/
./grakn-core-all/server/…
```

This restores the behaviour we previously had.