### PR TITLE
the distribution() macro now takes in 'name' attribute

### DIFF
--- a/distribution/rules.bzl
+++ b/distribution/rules.bzl
@@ -151,7 +151,8 @@ def deploy_rpm(name,
     )
 
 
-def distribution(targets,
+def distribution(name,
+                 targets,
                  additional_files,
                  output_filename,
                  empty_directories = [],
@@ -167,7 +168,7 @@ def distribution(targets,
         all_java_deps.append(target_name)
 
     pkg_tar(
-        name="distribution_tgz",
+        name="{}-tgz".format(name),
         deps = all_java_deps,
         extension = "tgz",
         files = additional_files,
@@ -176,8 +177,8 @@ def distribution(targets,
     )
 
     tgz2zip(
-        name = "distribution",
-        tgz = ":distribution_tgz",
+        name = "{}".format(name),
+        tgz = ":{}-tgz".format(name),
         output_filename = output_filename,
         visibility = ["//visibility:public"]
     )

--- a/distribution/rules.bzl
+++ b/distribution/rules.bzl
@@ -177,7 +177,7 @@ def distribution(name,
     )
 
     tgz2zip(
-        name = "{}".format(name),
+        name = name,
         tgz = ":{}-tgz".format(name),
         output_filename = output_filename,
         visibility = ["//visibility:public"]


### PR DESCRIPTION
```
distribution(
    name = "kekeke", # can specify name
    targets = {
        "//runner:benchmark-runner": "runner/services/lib/",
    },
    additional_files = {
        "//runner:runner": 'runner.sh'
    },
    empty_directories = [
        "data/logs"
    ],
    output_filename = "benchmark-runner",
)
```