### PR TITLE
Restructure distribution rules; fix #20

### DIFF
--- a/distribution/tgz2zip.py
+++ b/distribution/tgz2zip.py
@@ -26,7 +26,7 @@ import tarfile
 
 _, tgz_fn, zip_fn, prefix = sys.argv
 
-with tarfile.open(tgz_fn, mode='r') as tgz:
+with tarfile.open(tgz_fn, mode='r:gz') as tgz:
     with zipfile.ZipFile(zip_fn, 'w', compression=zipfile.ZIP_DEFLATED) as zip:
         for tarinfo in tgz.getmembers():
             f = ''


### PR DESCRIPTION
* Adds `distribution_structure`, `distribution_zip`, `distribution_deb`, `distribution_rpm` macros — see issue description for details
* Removes `distribution` macro